### PR TITLE
docker: Remove moving app to public path

### DIFF
--- a/docker/cmd.sh
+++ b/docker/cmd.sh
@@ -31,23 +31,6 @@ then
     exit 1
 fi
 
-if [ "$PUBLIC_PATH" != "$PUBLIC_PATH_DEFAULT" ]
-then
-    HTML_DIR_TEMP="$(mktemp -d)/site"
-    command="mv $HTML_DIR $HTML_DIR_TEMP"
-    echo + $command
-    eval $command
-
-    HTML_DIR=$(echo $HTML_DIR/$PUBLIC_PATH | tr -s /)
-    HTML_DIR=${HTML_DIR%/} # e.g., /app/site/vue
-    command="mkdir -p $(dirname $HTML_DIR)"
-    echo + $command
-    eval $command
-    command="mv $HTML_DIR_TEMP $HTML_DIR"
-    echo + $command
-    eval $command
-fi
-
 ##__________________________________________________________________||
 (
     command="cd $HTML_DIR"


### PR DESCRIPTION
This will decouple the `vue.config.js` `publicPath` definition from the path being served by nginx within the container. This will allow a proxy to sit in front of this container and pass to a subdirectory specified with `PUBLIC_PATH`.

In other words, the container will always serve from `/`, but allow `PUBLIC_PATH` to be defined identically to a separate proxy location to serve on a subdirectory like http://example.com/nextline/.

Here's an example docker-compose config that demonstrates what I mean:
```
version: '3.7'
networks:
  default:

services:
  nextline-web:
    image: nextline-web:test
    container_name: nextline-web
    environment:
      - API_HTTP=http://localhost/nextline-api/
      - PUBLIC_PATH=/nextline/

  nextline-backend:
    image: ghcr.io/simonsobs/so-daq-sequencer:v0.1.3
    container_name: nextline-backend

  nginx:
    image: nginx
    restart: always
    volumes:
     - ./nginx.conf:/etc/nginx/nginx.conf:ro
    ports:
     - "127.0.0.1:80:80"
```

And accompanying nginx config:
```
user       nginx;  ## Default: nobody
worker_processes  1;  ## Default: 1

error_log  /var/log/nginx/error.log;
pid        /var/run/nginx.pid;
worker_rlimit_nofile 8192;

events {
  worker_connections  1024;  ## Default: 1024
}

http {
  include    /etc/nginx/mime.types;
  #include    /etc/nginx/proxy.conf; #include    /etc/nginx/fastcgi.conf;
  index    index.html index.htm index.php;

  default_type application/octet-stream;
  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
    '"$request" $body_bytes_sent "$http_referer" '
    '"$http_user_agent" "$http_x_forwarded_for"';
  access_log   /var/log/nginx/access.log  main;
  sendfile     on;
  tcp_nopush   on;
  server_names_hash_bucket_size 128; # this seems to be required for some vhosts

  # Nextline Websocket Connection
  # For websocket connection upgrade
  # https://www.nginx.com/blog/websocket-nginx/
  map $http_upgrade $connection_upgrade {
      default upgrade;
      '' close;
  }

  server { # simple reverse-proxy
    listen       80;
    server_name  localhost;
    access_log   /var/log/nginx/nginx.log;
    root         /usr/share/nginx/html;

    # serve static files
    # location ~ ^/(images|javascript|js|css|flash|media|static)/  {
    #   root    /var/www/virtual/big.server.com/htdocs;
    #   expires 30d;
    # }

    #auth_basic "Restricted Content";
    #auth_basic_user_file /etc/nginx/.htpasswd;

    location /nextline/ {
      proxy_pass http://nextline-web/;
    }
    location /nextline-api/ {
      proxy_pass http://nextline-backend:8000/;

      # https://www.nginx.com/blog/websocket-nginx/
      proxy_http_version 1.1;
      proxy_set_header Upgrade $http_upgrade;
      proxy_set_header Connection $connection_upgrade;
      proxy_set_header Host $host;
      #proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    }
  }
}
```

If you were to run this without the modification, nextline would being expecting to be served at http://example.com/nextline/nextline/ and internal paths to directories like `/js/` would be broken.