### PR TITLE
Downgrade `vuetify` to 3.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "pinia": "~3.0.1",
     "vue": "~3.5.13",
     "vue-router": "^4.5.0",
-    "vuetify": "~3.7.13"
+    "vuetify": "3.7.3"
   },
   "devDependencies": {
     "@babel/core": "^7.26.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5704,10 +5704,10 @@ vue@^3.5.13, vue@~3.5.13:
     "@vue/server-renderer" "3.5.13"
     "@vue/shared" "3.5.13"
 
-vuetify@~3.7.13:
-  version "3.7.13"
-  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-3.7.13.tgz#c7aad28d2e3eae2dd30f0df0acf6dbe79e23dfdc"
-  integrity sha512-4+RuQU+zLtXhlN2eZUpKXums9ftzUzhMeiNEJvvJY4XdOzVwUCth2dTnEZkSF6EKdLHk3WhtRk0cIWXZxpBvcw==
+vuetify@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-3.7.3.tgz#0e89f7f0298d452510bcbc01b0e9b53a5ce6e883"
+  integrity sha512-bpuvBpZl1/+nLlXDgdVXekvMNR6W/ciaoa8CYlpeAzAARbY8zUFSoBq05JlLhkIHI58AnzKVy4c09d0OtfYAPg==
 
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
The layout breaks with `vuetify` 3.7.4 and above: https://github.com/simonsobs/nextline-web/issues/93