### PR TITLE
Use treeshaking on Vuetify

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "type-fest": "^4.35.0",
     "typescript": "~5.7.3",
     "vite": "~6.1.1",
+    "vite-plugin-vuetify": "2.1.0",
     "vite-plugin-monaco-editor": "^1.1.0",
     "vite-plugin-package-version": "^1.1.0",
     "vitest": "~3.0.6"

--- a/src/components/main/run-frame/top-bar/ActionRunning.vue
+++ b/src/components/main/run-frame/top-bar/ActionRunning.vue
@@ -49,6 +49,8 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { useDisplay } from "vuetify";
+import { VMenu } from "vuetify/components/VMenu"
+import { VBottomSheet } from "vuetify/components/VBottomSheet"
 import {
   useCtrlInterruptMutation,
   useCtrlTerminateMutation,
@@ -65,7 +67,7 @@ const { executeMutation: executeKill } = useCtrlKillMutation();
 
 const { mobile } = useDisplay();
 
-const menuComponent = computed(() => (mobile.value ? "VBottomSheet" : "VMenu"));
+const menuComponent = computed(() => (mobile.value ? VBottomSheet : VMenu));
 const menuAttributes = computed(() =>
   mobile.value ? {} : { location: "top", offset: 8 }
 );

--- a/src/components/main/trace-frame/script-editor/Actions.vue
+++ b/src/components/main/trace-frame/script-editor/Actions.vue
@@ -41,6 +41,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useDisplay } from "vuetify";
+import { VMenu } from "vuetify/components/VMenu"
+import { VBottomSheet } from "vuetify/components/VBottomSheet"
 import { useDevTool } from "@/utils/dev/enabled";
 interface Props {
   editing: boolean;
@@ -60,6 +62,6 @@ const emit = defineEmits<Emits>();
 
 const { mobile } = useDisplay();
 
-const menuComponent = computed(() => (mobile.value ? "VBottomSheet" : "VMenu"));
+const menuComponent = computed(() => (mobile.value ? VBottomSheet : VMenu));
 const menuAttributes = computed(() => (mobile.value ? {} : { location: "top" }));
 </script>

--- a/src/components/schedule/auto-mode/auto-mode-button/modes/off/Button.vue
+++ b/src/components/schedule/auto-mode/auto-mode-button/modes/off/Button.vue
@@ -12,9 +12,11 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useDisplay } from "vuetify";
+import { VMenu } from "vuetify/components/VMenu"
+import { VBottomSheet } from "vuetify/components/VBottomSheet"
 import Dialog from "./Dialog.vue";
 const { mobile } = useDisplay();
-const menuComponent = computed(() => (mobile.value ? "VBottomSheet" : "VMenu"));
+const menuComponent = computed(() => (mobile.value ? VBottomSheet : VMenu));
 </script>
 
 <style scoped>

--- a/src/components/schedule/auto-mode/auto-mode-button/modes/queue/Button.vue
+++ b/src/components/schedule/auto-mode/auto-mode-button/modes/queue/Button.vue
@@ -12,9 +12,11 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useDisplay } from "vuetify";
+import { VMenu } from "vuetify/components/VMenu"
+import { VBottomSheet } from "vuetify/components/VBottomSheet"
 import Dialog from "./Dialog.vue";
 const { mobile } = useDisplay();
-const menuComponent = computed(() => (mobile.value ? "VBottomSheet" : "VMenu"));
+const menuComponent = computed(() => (mobile.value ? VBottomSheet : VMenu));
 </script>
 
 <style scoped>

--- a/src/components/schedule/auto-mode/auto-mode-button/modes/scheduler/Button.vue
+++ b/src/components/schedule/auto-mode/auto-mode-button/modes/scheduler/Button.vue
@@ -14,9 +14,11 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useDisplay } from "vuetify";
+import { VMenu } from "vuetify/components/VMenu"
+import { VBottomSheet } from "vuetify/components/VBottomSheet"
 import Dialog from "./Dialog.vue";
 const { mobile } = useDisplay();
-const menuComponent = computed(() => (mobile.value ? "VBottomSheet" : "VMenu"));
+const menuComponent = computed(() => (mobile.value ? VBottomSheet : VMenu));
 </script>
 
 <style scoped>

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,8 @@ import SuspenseC from "@/components/SuspenseC.vue";
 
 // Types of global components are exported from src/global-components.d.ts
 
+import "@/styles/variables.scss";
+
 const app = createApp({ render: () => h(App) });
 
 app.config.errorHandler = (err, vm, info) => {

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -7,7 +7,7 @@ import { aliases, mdi } from "vuetify/iconsets/mdi";
 
 import * as labsComponents from "vuetify/labs/components";
 
-import "@/styles/variables.scss";
+import "@/styles/vuetify.scss";
 
 const vuetify = createVuetify({
   components: { ...components, ...labsComponents },

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -1,17 +1,12 @@
 import "vuetify/styles";
 import { createVuetify } from "vuetify";
-import * as components from "vuetify/components";
-import * as directives from "vuetify/directives";
 import { md3 } from "vuetify/blueprints";
 import { aliases, mdi } from "vuetify/iconsets/mdi";
 
-import * as labsComponents from "vuetify/labs/components";
 
 import "@/styles/vuetify.scss";
 
 const vuetify = createVuetify({
-  components: { ...components, ...labsComponents },
-  directives,
   blueprint: md3,
   icons: {
     defaultSet: "mdi",

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,38 +1,12 @@
-// Vuetify supports 100, 300, 400, 500, 700, 900 font weights and italicized text
-// https://vuetifyjs.com/en/styles/text-and-typography/
-
 // Fira Code: https://fonts.google.com/specimen/Fira+Code
 // For code in Monaco Editor
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;500;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;500;700&display=swap");
 
 // Noto Sans Japanese: https://fonts.google.com/noto/specimen/Noto+Sans+JP
 // For the arrow (⮕) in Monaco Editor Glyph Margin
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100;300;400;500;700;900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100;300;400;500;700;900&display=swap");
 
 html,
-body,
-#app,
-.v-application,
-.v-application__wrap {
+body {
   height: 100%;
-}
-
-.v-btn {
-  text-transform: capitalize;
-}
-
-.v-table {
-  background: rgb(var(--v-theme-surface-container-lowest));
-  border: 1px solid rgb(var(--v-theme-outline-variant));
-  border-radius: 8px;
-}
-
-.v-table__wrapper > table > thead > tr th,
-.v-table__wrapper > table tbody > tr > td {
-  background-color: inherit;
-}
-
-.v-data-table .v-table__wrapper > table > thead > tr th,
-.v-data-table .v-table__wrapper > table tbody > tr > td {
-  background-color: inherit;
 }

--- a/src/styles/vuetify.scss
+++ b/src/styles/vuetify.scss
@@ -1,0 +1,30 @@
+// Vuetify supports 100, 300, 400, 500, 700, 900 font weights and italicized text
+// https://vuetifyjs.com/en/styles/text-and-typography/
+
+html,
+body,
+#app,
+.v-application,
+.v-application__wrap {
+  height: 100%;
+}
+
+.v-btn {
+  text-transform: capitalize;
+}
+
+.v-table {
+  background: rgb(var(--v-theme-surface-container-lowest));
+  border: 1px solid rgb(var(--v-theme-outline-variant));
+  border-radius: 8px;
+}
+
+.v-table__wrapper > table > thead > tr th,
+.v-table__wrapper > table tbody > tr > td {
+  background-color: inherit;
+}
+
+.v-data-table .v-table__wrapper > table > thead > tr th,
+.v-data-table .v-table__wrapper > table tbody > tr > td {
+  background-color: inherit;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath, URL } from "node:url";
 import { defineConfig, loadEnv } from "vite";
 import vue from "@vitejs/plugin-vue";
+import vuetify from "vite-plugin-vuetify";
 import loadVersion from "vite-plugin-package-version";
 import graphql from "@rollup/plugin-graphql";
 // import monacoEditorPlugin from "vite-plugin-monaco-editor";
@@ -31,6 +32,10 @@ export default ({ mode }) => {
     esbuild: { target: "es2022" },
     plugins: [
       vue(),
+      vuetify({
+        autoImport: { labs: true },
+        styles: { configFile: "src/styles/vuetify.scss" },
+      }),
       loadVersion(),
       // @ts-ignore
       graphql(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2257,6 +2257,13 @@
   dependencies:
     vue-demi "^0.13.11"
 
+"@vuetify/loader-shared@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@vuetify/loader-shared/-/loader-shared-2.1.0.tgz#29410dce04a78fa9cd40c4d9bc417b8d61ce5103"
+  integrity sha512-dNE6Ceym9ijFsmJKB7YGW0cxs7xbYV8+1LjU6jd4P14xOt/ji4Igtgzt0rJFbxu+ZhAzqz853lhB0z8V9Dy9cQ==
+  dependencies:
+    upath "^2.0.1"
+
 "@vueuse/core@12.7.0", "@vueuse/core@^12.7.0":
   version "12.7.0"
   resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-12.7.0.tgz#b9c3880e9c01d9db86029c6a58412f1b1922497e"
@@ -2991,7 +2998,7 @@ debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
-debug@^4.4.0:
+debug@^4.3.3, debug@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
@@ -5589,6 +5596,11 @@ unixify@^1.0.0:
   dependencies:
     normalize-path "^2.1.1"
 
+upath@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.1.tgz#50c73dea68d6f6b990f51d279ce6081665d61a8b"
+  integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
+
 update-browserslist-db@^1.0.13:
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz#3c5e4f5c083661bd38ef64b6328c26ed6c8248c4"
@@ -5671,6 +5683,15 @@ vite-plugin-package-version@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/vite-plugin-package-version/-/vite-plugin-package-version-1.1.0.tgz#7d8088955aa21e4ec93353c98992b3f58c4bf13c"
   integrity sha512-TPoFZXNanzcaKCIrC3e2L/TVRkkRLB6l4RPN/S7KbG7rWfyLcCEGsnXvxn6qR7fyZwXalnnSN/I9d6pSFjHpEA==
+
+vite-plugin-vuetify@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-vuetify/-/vite-plugin-vuetify-2.1.0.tgz#56767be099fd18a44ec2f9831d49269722e0e538"
+  integrity sha512-4wEAQtZaigPpwbFcZbrKpYwutOsWwWdeXn22B9XHzDPQNxVsKT+K9lKcXZnI5JESO1Iaql48S9rOk8RZZEt+Mw==
+  dependencies:
+    "@vuetify/loader-shared" "^2.1.0"
+    debug "^4.3.3"
+    upath "^2.0.1"
 
 "vite@^5.0.0 || ^6.0.0", vite@~6.1.1:
   version "6.1.1"


### PR DESCRIPTION
As described in https://vuetifyjs.com/en/features/treeshaking/.

This reduces the chunk size to below the Vite default warning threshold of 500 kB.

Before:
```
dist/assets/index-DKbRuRzt.js                   530.37 kB │ gzip: 160.86 kB
```

After:
```
dist/assets/index-CM3Y18Jc.js                   278.46 kB │ gzip:  87.93 kB
```
